### PR TITLE
Feat: adding golangci-lint config and the pipeline lint step

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -14,6 +14,9 @@ permissions:
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
   pull-requests: read
 
+env:
+  GO_VERSION: '1.19'
+
 jobs:
 
   build:
@@ -24,7 +27,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: ${{ env.GO_VERSION }}
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
@@ -37,3 +40,11 @@ jobs:
 
     - name: Test
       run: go test -v ./...
+
+    - name: Lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: latest
+        skip-cache: true
+        skip-build-cache: true
+        skip-pkg-cache: true

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -29,12 +29,6 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v3
-      with:
-        # Optional: show only new issues if it's a pull request. The default value is `false`.
-        only-new-issues: true
-
     - name: Build
       run: go build -v ./...
 
@@ -45,6 +39,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: latest
+        only-new-issues: true
         skip-cache: true
         skip-build-cache: true
         skip-pkg-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,14 +5,66 @@
 run:
   # The default concurrency value is the number of available CPU.
   concurrency: 2
+  timeout: 1m
+  issues-exit-code: 1
+  tests: true
+  build-tags: []
+  skip-dirs: []
+  skip-dirs-use-default: true
+  skip-files: []
+  modules-download-mode: readonly
+  allow-parallel-runners: false
+  # Define the Go version limit.
+  # Use the same version as the project.
+  go: "1.19"
 
 # output configuration options
 output:
-
-# All available settings of specific linters.
-linters-settings:
+  print-issued-lines: true
+  print-linter-name: true
+  unique-by-line: true
+  format: github-actions
 
 linters:
+  enable-all: false
+  disable-all: true
+  fast: true
+  # List of enabled linters.
+  # Default: [].
+  enable:
+    - bodyclose
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - funlen
+    - gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - lll
+    - misspell
+    - nakedret
+    - noctx
+    - nolintlint
+    - revive
+    - staticcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - whitespace
+
   presets:
     - bugs
     - comment
@@ -27,10 +79,14 @@ linters:
     - style
     - test
     - unused
-  # Run only fast linters from enabled linters set (first run won't be fast)
-  fast: true
 
 issues:
+  exclude-use-default: true
+  exclude-case-sensitive: false
+  max-issues-per-linter: 50
+  max-same-issues: 3
+  new: false
 
 severity:
-
+  default-severity: warning
+  case-sensitive: false


### PR DESCRIPTION
Neste PR foram feitos os seguintes procedimentos:

- Inclusão (`./golangci.yaml`):
  - Adicionado o arquivo com as configurações a serem utilizadas pelo golangci-lint.

- Alteração (`.github/workflows/go.yaml`):
  - Alterado  para utilizar a versão do GO como variável de ambiente. Além do CI, essa variável também é utilizada no arquivo `./golangci.yaml`, deixando a versão do consistente no projeto, sendo necessário modificar apenas no ENV.
  -  Modificado a versão do `actions/setup-go@v4` passando por parâmetro a variável de ambiente.
  - Adicionado step de Lint (`golangci/golangci-lint-action@v3`) desativando o cache, para evitar comportamento anômalo.

Exemplo detectando erros:

![image](https://user-images.githubusercontent.com/38040926/235511904-6c525cd3-5ad8-4eec-97e0-fb0f740f5143.png)

Execução normal e sem erros:

![image](https://user-images.githubusercontent.com/38040926/235512014-fc474797-3999-40ca-9953-1b56c3bc6cf7.png)
