### PR TITLE
Remove preset do golangci-linter e nolint desnecessários

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -65,21 +65,6 @@ linters:
     - unused
     - whitespace
 
-  presets:
-    - bugs
-    - comment
-    - complexity
-    - error
-    - format
-    - import
-    - metalinter
-    - module
-    - performance
-    - sql
-    - style
-    - test
-    - unused
-
 issues:
   exclude-use-default: true
   exclude-case-sensitive: false

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -25,7 +25,6 @@ var startCmd = &cobra.Command{
 
 			cfg.Logger.Info("finalizando o serviço")
 
-			//nolint
 			// TODO: colocar uma deadline para o shutdown
 			if err := svc.Shutdown(ctx); err != nil {
 				cfg.Logger.Error("erro ao finalizar o serviço: %w", zap.Error(err))

--- a/pkg/server/http_handler_test.go
+++ b/pkg/server/http_handler_test.go
@@ -1,4 +1,4 @@
-package server //nolint
+package server
 
 import (
 	"io"


### PR DESCRIPTION
Como discutido em #28, remove linter configurados de forma implícita através do preset.
Closes #28 . 