### PR TITLE
Remove nolint desnecessário

### DIFF
--- a/pkg/server/http_test.go
+++ b/pkg/server/http_test.go
@@ -1,4 +1,4 @@
-package server //nolint
+package server
 
 import (
 	"testing"


### PR DESCRIPTION
Remove nolint removido em #31, mas que por algum motivo retornou durante incorporações posteriores.

Closes #32
