### PR TITLE
Remove depguard da lista de linters

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: 1.53.2
+        version: v1.53.2
         only-new-issues: true
         skip-cache: true
         skip-build-cache: true

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -38,7 +38,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
-        version: latest
+        version: 1.53.2
         only-new-issues: true
         skip-cache: true
         skip-build-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,7 +33,6 @@ linters:
   # Default: [].
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - dupl
     - errcheck


### PR DESCRIPTION
Remove depguard, já que seu uso não faz sentido pra gente, pelo menos não agora.
Além disso, afixa a versão do golangci-lint para que novas versões não quebrem nosso build.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
