### PR TITLE
Instala o comando air via make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ build:
 
 .PHONY: air
 air:
+	@if ! air version &> /dev/null; then go install github.com/cosmtrek/air@v1.44.0; fi
 	@air
 
 .PHONY: install-tools


### PR DESCRIPTION
Closes #60.

Este PR adiciona um comportamento, ao target `air` do Makefile, que verifica se o comando existe na máquina local. Caso não existir o comando é instalado.