### PR TITLE
fix: passa a utilizar ms como unidade base para timeout

### DIFF
--- a/pkg/server/http.go
+++ b/pkg/server/http.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/dose-na-nuvem/customers/config"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -29,7 +30,7 @@ func NewHTTP(cfg *config.Cfg, customerHandler http.Handler) (*HTTP, error) {
 	srv := &http.Server{
 		Addr:              cfg.Server.HTTP.Endpoint,
 		Handler:           mux,
-		ReadHeaderTimeout: cfg.Server.HTTP.ReadHeaderTimeout,
+		ReadHeaderTimeout: cfg.Server.HTTP.ReadHeaderTimeout * time.Millisecond,
 	}
 
 	return HTTPWithServer(cfg, srv)


### PR DESCRIPTION
Nesse PR consertamos a utilização do tempo passado para timeout dos headers, de nano segundos para milissegundos.

Closes #63 